### PR TITLE
fix(retro_wrapper): round mohn's rho values in table

### DIFF
--- a/R/retro_wrapper.R
+++ b/R/retro_wrapper.R
@@ -205,14 +205,18 @@ retro_wrapper <- function(mydir,  model_settings) {
 
   # Make table for document with caption
   rhos %>%
-    tidyr::spread(key = "type", value = "values") %>%
     dplyr::mutate(
       Quantity = gsub("(^[FSB]+$)", "\\\\emph{\\1}", Quantity),
+      values = round(unlist(values), 3)
     ) %>%
+    tidyr::spread(key = "type", value = "values") %>%
     kableExtra::kbl(
-      format = "latex", booktabs = TRUE, digits = 2, longtable = TRUE,
+      format = "latex",
+      booktabs = TRUE,
+      longtable = FALSE,
       label = "RetroMohnsrho",
       escape = FALSE,
+      align = "r",
       caption = paste(
         "The magnitude of retrospective pattern",
         "(Mohn's rho; Mohn, 1999) given the removal of",


### PR DESCRIPTION
## Why

The "digits" argument of `kableExtra::kbl()` was not leading to the mohn's rho values being rounded.

Use round() but had to unlist() the listed column otherwise it didn't think that it was numeric. Kind of weird. But it works. Move spread to after manipulating the data frame.

No longer use longtable = TRUE b/c it is not needed for accessibility and it is best if this table is not split across pages. But, right align all the values because there can be negative numbers which makes left or center align annoying.