### PR TITLE
fix(pngfun): Move on.exit()

### DIFF
--- a/R/jitter_wrapper.R
+++ b/R/jitter_wrapper.R
@@ -101,6 +101,7 @@ jitter_wrapper <- function(mydir, model_settings) {
   ylab <- "Change in negative log-likelihood"
   xlab <- "Iteration"
   pngfun(wd = jitter_dir, file = paste0("Jitter_", model_settings$jitter_fraction, ".png"), h = 12, w = 9)
+  on.exit(grDevices::dev.off(), add = TRUE)
   plot(keys, like - est,
     ylim = c(ymin, ymax), cex.axis = 1.25, cex.lab = 1.25,
     ylab = ylab, xlab = xlab
@@ -125,6 +126,7 @@ jitter_wrapper <- function(mydir, model_settings) {
 
   if (ymax > 100) {
     pngfun(wd = jitter_dir, file = paste0("Jitter_Zoomed_SubPlot_", model_settings$jitter_fraction, ".png"), h = 12, w = 9)
+    on.exit(grDevices::dev.off(), add = TRUE)
     plot(keys, like - est,
       ylim = c(ymin, 100), cex.axis = 1.25, cex.lab = 1.25,
       ylab = ylab, xlab = xlab

--- a/R/pdf_fxn.R
+++ b/R/pdf_fxn.R
@@ -11,7 +11,6 @@
 pngfun <- function(wd, file, w = 7, h = 7, pt = 12) {
   file <- file.path(wd, file)
   cat("writing PNG to", file, "\n")
-  on.exit(grDevices::dev.off(), add = TRUE)
   grDevices::png(
     filename = file,
     width = w,

--- a/R/profile_plot.R
+++ b/R/profile_plot.R
@@ -90,6 +90,7 @@ profile_plot <- function(mydir, rep, para, profilesummary) {
   }
 
   pngfun(wd = mydir, file = paste0("piner_panel_", para, ".png"), h = 7, w = 7)
+  on.exit(grDevices::dev.off(), add = TRUE)
   graphics::par(mfrow = panel)
   r4ss::SSplotProfile(
     summaryoutput = profilesummary, main = "Changes in total likelihood", profile.string = get,
@@ -155,6 +156,7 @@ profile_plot <- function(mydir, rep, para, profilesummary) {
   thresh <- as.numeric(profilesummary$minbthresh[1]) # ifelse(btarg == 0.40, 0.25, ifelse(btarg == 0.25, 0.125, -1))    
 
   pngfun(wd = mydir, file = paste0("parameter_panel_", para, ".png"), h = 7, w = 7)
+  on.exit(grDevices::dev.off(), add = TRUE)
   graphics::par(mfrow = c(2, 2), mar = c(4, 4, 2, 2), oma = c(1, 1, 1, 1))
   # parameter vs. likelihood
   plot(x, like, type = "l", lwd = 2, xlab = label, ylab = "Change in -log-likelihood", ylim = ylike)


### PR DESCRIPTION
Move the `on.exit()` call from `pngfun()` to where it is called. Calling it from `pngfun()` caused the device to be closed before it was even printed to.

Close #34

Thanks to @shcaba for reporting this error, which I introduced with 4fb523a