### PR TITLE
Remove .exe so can use for macos and linux

### DIFF
--- a/R/profile_wrapper.R
+++ b/R/profile_wrapper.R
@@ -39,8 +39,6 @@ profile_wrapper <- function(mydir, model_settings) {
     f(x / accuracy) * accuracy
   }
 
-  r4ss::check_exe(exe = model_settings$exe, dir = file.path(mydir, model_settings$base_name))
-
   N <- nrow(model_settings$profile_details)
 
   for (aa in 1:N) {

--- a/R/profile_wrapper.R
+++ b/R/profile_wrapper.R
@@ -39,11 +39,13 @@ profile_wrapper <- function(mydir, model_settings) {
     f(x / accuracy) * accuracy
   }
 
-  check_exe <- model_settings$exe
-  # check whether exe is in directory
-  if (!check_exe %in% list.files(file.path(mydir, model_settings$base_name))) {
-    stop("Executable not found in ", file.path(mydir, model_settings$base_name))
-  }
+  # check_exe <- model_settings$exe
+  # # check whether exe is in directory
+  # if (!check_exe %in% list.files(file.path(mydir, model_settings$base_name))) {
+  #   stop("Executable not found in ", file.path(mydir, model_settings$base_name))
+  # }
+
+  r4ss::check_exe(file.path(mydir, model_settings$base_name))
 
   N <- nrow(model_settings$profile_details)
 

--- a/R/profile_wrapper.R
+++ b/R/profile_wrapper.R
@@ -39,7 +39,7 @@ profile_wrapper <- function(mydir, model_settings) {
     f(x / accuracy) * accuracy
   }
 
-  check_exe <- paste0(model_settings$exe, ".exe")
+  check_exe <- model_settings$exe
   # check whether exe is in directory
   if (!check_exe %in% list.files(file.path(mydir, model_settings$base_name))) {
     stop("Executable not found in ", file.path(mydir, model_settings$base_name))

--- a/R/profile_wrapper.R
+++ b/R/profile_wrapper.R
@@ -39,12 +39,6 @@ profile_wrapper <- function(mydir, model_settings) {
     f(x / accuracy) * accuracy
   }
 
-  # check_exe <- model_settings$exe
-  # # check whether exe is in directory
-  # if (!check_exe %in% list.files(file.path(mydir, model_settings$base_name))) {
-  #   stop("Executable not found in ", file.path(mydir, model_settings$base_name))
-  # }
-
   r4ss::check_exe(file.path(mydir, model_settings$base_name, model_settings$exe))
 
   N <- nrow(model_settings$profile_details)

--- a/R/profile_wrapper.R
+++ b/R/profile_wrapper.R
@@ -39,7 +39,7 @@ profile_wrapper <- function(mydir, model_settings) {
     f(x / accuracy) * accuracy
   }
 
-  r4ss::check_exe(file.path(mydir, model_settings$base_name, model_settings$exe))
+  r4ss::check_exe(exe = model_settings$exe, dir = file.path(mydir, model_settings$base_name))
 
   N <- nrow(model_settings$profile_details)
 

--- a/R/profile_wrapper.R
+++ b/R/profile_wrapper.R
@@ -45,7 +45,7 @@ profile_wrapper <- function(mydir, model_settings) {
   #   stop("Executable not found in ", file.path(mydir, model_settings$base_name))
   # }
 
-  r4ss::check_exe(file.path(mydir, model_settings$base_name))
+  r4ss::check_exe(file.path(mydir, model_settings$base_name, model_settings$exe))
 
   N <- nrow(model_settings$profile_details)
 

--- a/R/run_diagnostics.R
+++ b/R/run_diagnostics.R
@@ -13,6 +13,8 @@
 
 run_diagnostics <- function(mydir, model_settings) {
 
+  r4ss::check_exe(exe = model_settings$exe, dir = file.path(mydir, model_settings$base_name))
+  
   # Check for Report file
   model_dir <- file.path(mydir, paste0(model_settings$base_name))
 


### PR DESCRIPTION
I have been working on adding some things to Jason's SS-DL-tool app and he uses the {nwfscDiag} package to run profiles. However, it doesn't work on my mac because check_exe looks specifically for a Windows exe (since the check_exe is an output of pasting the input exe names with ".exe"). I have removed ".exe" from that to allow it to be used for mac and linux executables.

I tested my fork with the SS-DL-tool app that I have on my mac and it works with my modification.